### PR TITLE
Feat: ToastAlert

### DIFF
--- a/frontend/CSS/geral.css
+++ b/frontend/CSS/geral.css
@@ -1,0 +1,29 @@
+html, body {
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Poppins';
+}
+
+.geralContainer {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    height: 100%;
+}
+
+.toastAlert {
+    width: auto;
+    height: auto;
+    display: block;
+    position: fixed;
+    top: 5%;
+    right: 1.5%;
+    font-size: 24px;
+    color: white;
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+    z-index: 20;
+}

--- a/frontend/JS/toastAlert.js
+++ b/frontend/JS/toastAlert.js
@@ -1,0 +1,51 @@
+let activeToast = null;
+
+function toastAlert(type, message) {
+    if (activeToast) {
+        activeToast.remove();
+    }
+
+    const toastAlert = document.createElement('div');
+    toastAlert.classList.add('toastAlert');
+
+    const progressBar = document.createElement('div');
+    progressBar.style.height = '5px';
+    progressBar.style.width = '100%';
+    progressBar.style.transition = `width 3000ms linear`;
+
+    if (type === 'success') {
+        toastAlert.style.backgroundColor = '#2ECC71';
+        toastAlert.style.border = '2px solid #C2D1BC';
+        progressBar.style.backgroundColor = '#4CAF50';
+    } else if (type === 'error') {
+        toastAlert.style.backgroundColor = '#E14D45';
+        toastAlert.style.border = '2px solid #B9A09D';
+        progressBar.style.backgroundColor = '#921919';
+    } else if (type === 'warn') {
+        toastAlert.style.backgroundColor = '#F39C12';
+        toastAlert.style.border = '2px solid #C2D1BC';
+        progressBar.style.backgroundColor = '#c27809';
+    }
+    
+    const messageElement = document.createElement('div');
+    messageElement.textContent = message;
+    messageElement.style.padding = '10px';
+
+    toastAlert.appendChild(messageElement);
+    toastAlert.appendChild(progressBar);
+
+    document.body.appendChild(toastAlert);
+
+    setTimeout(() => {
+        progressBar.style.width = '0';
+    }, 100);
+
+    setTimeout(() => {
+        toastAlert.remove();
+        if (activeToast === toastAlert) {
+            activeToast = null;
+        }
+    }, 3000);
+
+    activeToast = toastAlert;
+}


### PR DESCRIPTION
Adicionado uma função que gera um toastAlert, que é uma forma mais bonita de enviar mensagens de erro, sucesso, ou aviso para o cliente.
Para sua usabilidade, é necessário apenas linkar o arquivo JS do mesmo nas páginas onde ele for necessário, então chamar sua função juntamente com os parâmetros (warn, success ou error, seguido da mensagem). Exemplo: toastAlert ('error', 'Erro ao listar produtos')
![image](https://github.com/user-attachments/assets/962dbead-9829-4a4f-9522-4f99689b787e)
![image](https://github.com/user-attachments/assets/36c746aa-7efa-458c-8765-cf29ffd93c1f)
![image](https://github.com/user-attachments/assets/e4bd15f5-7a8c-4b52-a12f-7c7bcb595293)
